### PR TITLE
Use classifiers to specify the license.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ setup(
     description="Make in Python",
     url="https://github.com/kshramt/buildpy",
     author="kshramt",
-    license="GPL-3.0",
     packages=[
         "buildpy.v1",
         "buildpy.v2",
@@ -59,6 +58,9 @@ setup(
         "google-cloud-bigquery",
         "google-cloud-storage",
         "psutil",
+    ],
+    classifiers=[
+        'License :: OSI Approved :: GNU General Public License v3 (GPLv3)'
     ],
     data_files=[(".", ["LICENSE.txt"])],
     zip_safe=True,


### PR DESCRIPTION
Classifiers are a standard way of specifying a license, and make it easy
for automated tools to properly detect the license of the package.

The "license" field should only be used if the license has no
corresponding Trove classifier.